### PR TITLE
fix(log): print full object

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,6 @@
+// When using console this will make it print the whole object. and not [Object] when it's too deep
+require("util").inspect.defaultOptions.depth = null;
+
 const express = require('express');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');


### PR DESCRIPTION
when logging an object it will print the entire object instead of cutting it when it reached some depth level